### PR TITLE
Fix incorrect help message

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -190,7 +190,7 @@ namespace Dalamud {
 
             CommandManager.AddHandler("/xlbonus", new CommandInfo(OnRouletteBonusNotifyCommand)
             {
-                HelpMessage = "Notify when a roulette has a bonus you specified. Usage: /xlitem <roulette name> <role name>"
+                HelpMessage = "Notify when a roulette has a bonus you specified. Usage: /xlbonus <roulette name> <role name>"
             });
         }
 


### PR DESCRIPTION
Noticed an incorrect help message.

While I'm looking at this area, is there a way to clear the roulette notification? I can't see one.

I wouldn't mind adding one if you specify what syntax you prefer.