### PR TITLE
Add some icon swaps, standardize others.

### DIFF
--- a/Dalamud/Configuration/CustomComboPreset.cs
+++ b/Dalamud/Configuration/CustomComboPreset.cs
@@ -97,7 +97,7 @@ namespace XIVLauncher.Dalamud
         GunbreakerDemonSlaughterCombo = 1L << 22,
 
         // MACHINIST
-        [CustomComboInfo("(Heated) Shot Combo", "Replace UNHEATED Split shot with its combo chain or with Heat Blast when overheated.", 31)]
+        [CustomComboInfo("(Heated) Shot Combo", "Replace UNHEATED Split Shot with its combo chain or with Heat Blast when overheated.", 31)]
         MachinistMainCombo = 1L << 23,
 
         [CustomComboInfo("Spread Shot Heat", "Replace Spread Shot with Auto Crossbow when overheated.", 31)]

--- a/Dalamud/Configuration/CustomComboPreset.cs
+++ b/Dalamud/Configuration/CustomComboPreset.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace XIVLauncher.Dalamud
 {
 
-    //CURRENT HIGHEST FLAG IS 45
+    //CURRENT HIGHEST FLAG IS 46
     [Flags]
     public enum CustomComboPreset : long
     {
@@ -16,6 +16,9 @@ namespace XIVLauncher.Dalamud
         // DRAGOON
         [CustomComboInfo("Jump + Mirage Dive", "Replace Jump with Mirage Dive when Dive Ready", 22)]
         DragoonJumpFeature = 1L << 44,
+
+        [CustomComboInfo("BOTD Into Stardiver", "Replace Blood of the Dragon with Stardiver when in Life of the Dragon", 22)]
+        DragoonBOTDFeature = 1L << 46,
 
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain", 22)]
         DragoonCoerthanTormentCombo  = 1L << 0,

--- a/Dalamud/Configuration/CustomComboPreset.cs
+++ b/Dalamud/Configuration/CustomComboPreset.cs
@@ -7,13 +7,16 @@ using System.Threading.Tasks;
 namespace XIVLauncher.Dalamud
 {
 
-    //CURRENT HIGHEST FLAG IS 44
+    //CURRENT HIGHEST FLAG IS 45
     [Flags]
     public enum CustomComboPreset : long
     {
         None   = 0,
 
         // DRAGOON
+        [CustomComboInfo("Jump + Mirage Dive", "Replace Jump with Mirage Dive when Dive Ready", 22)]
+        DragoonJumpFeature = 1L << 44,
+
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain", 22)]
         DragoonCoerthanTormentCombo  = 1L << 0,
 
@@ -77,19 +80,22 @@ namespace XIVLauncher.Dalamud
         [CustomComboInfo("Hakke Mujinsatsu Combo", "Replace Hakke Mujinsatsu with its combo chain", 30)]
         NinjaHakkeMujinsatsuCombo = 1L << 19,
 
+        [CustomComboInfo("Dream to Assassinate", "Replace Dream Within a Dream with Assassinate when Assassinate Ready", 30)]
+        NinjaAssassinateFeature = 1L << 45,
+
         // GUNBREAKER
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain", 37)]
         GunbreakerSolidBarrelCombo = 1L << 20,
 
-        [CustomComboInfo("Gnashing Fang Combo", "Replace Gnashing Fang with its combo chain", 37)]
+        [CustomComboInfo("Gnashing Fang Combo", "Replace Wicked Talon with its combo chain", 37)]
         GunbreakerGnashingFangCombo = 1L << 21,
 
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain", 37)]
         GunbreakerDemonSlaughterCombo = 1L << 22,
 
         // MACHINIST
-        [CustomComboInfo("Heated Clan Shot Combo/Heat", "Replace Heated Clan Shot with its combo chain or with Heat Blast when overheated.", 31)]
-        MachinistHeatedClanShotFeature = 1L << 23,
+        [CustomComboInfo("(Heated) Shot Combo", "Replace UNHEATED Split shot with its combo chain or with Heat Blast when overheated.", 31)]
+        MachinistMainCombo = 1L << 23,
 
         [CustomComboInfo("Spread Shot Heat", "Replace Spread Shot with Auto Crossbow when overheated.", 31)]
         MachinistSpreadShotFeature = 1L << 24,
@@ -112,10 +118,10 @@ namespace XIVLauncher.Dalamud
         [CustomComboInfo("Brand of Purgatory Combo", "Replaces Fountain of Fire with Brand of Purgatory when under the affect of Hellish Conduit.", 27)]
         SummonerBoPCombo = 1L << 38,
 
-        [CustomComboInfo("ED Fester", "Change Energy Drain into Fester while you have Aetherflow stacks.", 27)]
+        [CustomComboInfo("ED Fester", "Change Fester into Energy Drain when out of Aetherflow stacks.", 27)]
         SummonerEDFesterCombo = 1L << 39,
 
-        [CustomComboInfo("ES Painflare", "Change Energy Siphon into Painflare while you have Aetherflow stacks.", 27)]
+        [CustomComboInfo("ES Painflare", "Change Painflare into Energy Syphon when out of Aetherflow stacks.", 27)]
         SummonerESPainflareCombo = 1L << 40,
 
         [CustomComboInfo("DWT", "DWT.", 27)]

--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -15,7 +15,7 @@ namespace Dalamud.Game.ClientState
         protected override void Setup64Bit(SigScanner sig) {
             ActorTable = sig.Module.BaseAddress + 0x1BFBA38;
             LocalContentId = sig.Module.BaseAddress + 0x1C2E000;
-            JobGaugeData = sig.Module.BaseAddress + 0x1C00110;
+            JobGaugeData = sig.Module.BaseAddress + 0x1BFB110;
         }
     }
 }

--- a/Dalamud/Game/Internal/Gui/IconReplacer.cs
+++ b/Dalamud/Game/Internal/Gui/IconReplacer.cs
@@ -942,6 +942,7 @@ namespace Dalamud.Game.Internal.Gui {
             CustomIDs.Add(3566);
             CustomIDs.Add(92);
             CustomIDs.Add(2866);
+            CustomIDs.Add(3553);
             VanillaIDs.Add(0x3e75);
             VanillaIDs.Add(0x3e76);
             VanillaIDs.Add(0x3e77);

--- a/Dalamud/Game/Internal/Gui/IconReplacer.cs
+++ b/Dalamud/Game/Internal/Gui/IconReplacer.cs
@@ -36,11 +36,11 @@ namespace Dalamud.Game.Internal.Gui {
             this.Address.Setup(scanner);
 
             this.byteBase = scanner.Module.BaseAddress;
-            this.comboTimer = byteBase + 0x1BB8B50;
+            this.comboTimer = byteBase + 0x1BB3B50;
             //this.comboTimer = scanner.ScanText("E8 ?? ?? ?? ?? 80 7E 21 00") + 0x178;
             this.lastComboMove = this.comboTimer + 0x4;
 
-            this.playerLevel = byteBase + 0x1C30FA8 + 0x78;
+            this.playerLevel = byteBase + 0x1C2BFA8 + 0x78;
             //this.playerLevel = scanner.ScanText("E8 ?? ?? ?? ?? 88 45 EF") + 0x4D;
 
             CustomIDs = new HashSet<uint>();
@@ -411,11 +411,11 @@ namespace Dalamud.Game.Internal.Gui {
 
             // MACHINIST
 
-            // Replace Heated Clean Shot with Heated Clean Shot combo
+            // Replace Clean Shot with Heated Clean Shot combo
             // Or with Heat Blast when overheated.
             // For some reason the shots use their unheated IDs as combo moves
             if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistMainCombo)) {
-                if (actionID == 2866) {
+                if (actionID == 2873) {
                     MCHGauge gauge = this.dalamud.ClientState.JobGauges.Get<MCHGauge>();
                     // End overheat slightly early to prevent eager button mashing clipping your gcd with a fake 6th HB.
                     if (gauge.IsOverheated() && level >= 35 && gauge.OverheatTimeRemaining > 30) return 7410;
@@ -884,7 +884,7 @@ namespace Dalamud.Game.Internal.Gui {
         private unsafe delegate int* getArray(long* address);
 
         private unsafe IntPtr FindBuffAddress() {
-            IntPtr randomAddress = byteBase + 0x1C07BE0;
+            IntPtr randomAddress = byteBase + 0x1C02BE0;
             IntPtr num = Marshal.ReadIntPtr(randomAddress);
             IntPtr step2 = (IntPtr)(Marshal.ReadInt64(num) + 0x248);
             IntPtr step3 = Marshal.ReadIntPtr(step2);
@@ -941,8 +941,8 @@ namespace Dalamud.Game.Internal.Gui {
             CustomIDs.Add(7516);
             CustomIDs.Add(3566);
             CustomIDs.Add(92);
-            CustomIDs.Add(2866);
             CustomIDs.Add(3553);
+            CustomIDs.Add(2873);
             VanillaIDs.Add(0x3e75);
             VanillaIDs.Add(0x3e76);
             VanillaIDs.Add(0x3e77);
@@ -1100,9 +1100,9 @@ namespace Dalamud.Game.Internal.Gui {
             VanillaIDs.Add(0x8d4);
             VanillaIDs.Add(0x8d5);
             VanillaIDs.Add(0x8d7);
+            VanillaIDs.Add(0xb32);
             VanillaIDs.Add(0xb34);
             VanillaIDs.Add(0xb38);
-            VanillaIDs.Add(0xb39);
             VanillaIDs.Add(0xb3e);
             VanillaIDs.Add(0x12d);
             VanillaIDs.Add(0x15);

--- a/Dalamud/Game/Internal/Gui/IconReplacer.cs
+++ b/Dalamud/Game/Internal/Gui/IconReplacer.cs
@@ -110,12 +110,24 @@ namespace Dalamud.Game.Internal.Gui {
             
             // Change Jump/High Jump into Mirage Dive when Dive Ready
             if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature)) {
-                if(actionID == 92) {
+                if (actionID == 92) {
                     if (SearchBuffArray(1243)) {
                         return 7399;
                     }
                     if (level >= 74) return 16478;
                     return 92;
+                }
+            }
+
+            // Change Blood of the Dragon into Stardiver when in Life of the Dragon
+            if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonBOTDFeature)) {
+                if (actionID == 3553) {
+                    if (level >= 80) {
+                        if (this.dalamud.ClientState.JobGauges.Get<DRGGauge>().BOTDState == BOTDState.LOTD) {
+                            return 16480;
+                        }
+                    }
+                    return 3553;
                 }
             }
 

--- a/Dalamud/Game/Internal/Gui/IconReplacer.cs
+++ b/Dalamud/Game/Internal/Gui/IconReplacer.cs
@@ -501,7 +501,10 @@ namespace Dalamud.Game.Internal.Gui {
                     }
                     else {
                         if (gauge.IsBahamutReady()) return 7427;
-                        if (gauge.IsPhoenixReady()) return 16513;
+                        if (gauge.IsPhoenixReady()) {
+                            if (level == 80) return 16549;
+                            return 16513;
+                        }
                         return 3581;
                     }
                 }

--- a/Dalamud/Game/Internal/Gui/IconReplacer.cs
+++ b/Dalamud/Game/Internal/Gui/IconReplacer.cs
@@ -107,7 +107,17 @@ namespace Dalamud.Game.Internal.Gui {
             var level = Marshal.ReadByte(this.playerLevel);
 
             // DRAGOON
-            // TODO: Jump/High Jump into Mirage Dive
+            
+            // Change Jump/High Jump into Mirage Dive when Dive Ready
+            if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonJumpFeature)) {
+                if(actionID == 92) {
+                    if (SearchBuffArray(1243)) {
+                        return 7399;
+                    }
+                    if (level >= 74) return 16478;
+                    return 92;
+                }
+            }
 
             // Replace Coerthan Torment with Coerthan Torment combo chain
             if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.DragoonCoerthanTormentCombo)) {
@@ -345,6 +355,14 @@ namespace Dalamud.Game.Internal.Gui {
                 }
             }
 
+            //Replace Dream Within a Dream with Assassinate when Assassinate Ready
+            if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.NinjaAssassinateFeature)) {
+                if(actionID == 3566) {
+                    if (SearchBuffArray(1955)) return 2246;
+                    return 3566;
+                }
+            }
+
             // GUNBREAKER
 
             // Replace Solid Barrel with Solid Barrel combo
@@ -358,10 +376,10 @@ namespace Dalamud.Game.Internal.Gui {
                 }
             }
 
-            // Replace Gnashing Fang with Gnashing Fang combo
+            // Replace Wicked Talon with Gnashing Fang combo
             // TODO: Potentially add Contuation moves as well?
             if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.GunbreakerGnashingFangCombo)) {
-                if (actionID == 16146) {
+                if (actionID == 16150) {
                     byte ammoComboState = this.dalamud.ClientState.JobGauges.Get<GNBGauge>().AmmoComboStepNumber;
                     if (ammoComboState == 1) return 16147;
                     if (ammoComboState == 2) return 16150;
@@ -384,8 +402,8 @@ namespace Dalamud.Game.Internal.Gui {
             // Replace Heated Clean Shot with Heated Clean Shot combo
             // Or with Heat Blast when overheated.
             // For some reason the shots use their unheated IDs as combo moves
-            if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistHeatedClanShotFeature)) {
-                if (actionID == 7413) {
+            if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.MachinistMainCombo)) {
+                if (actionID == 2866) {
                     MCHGauge gauge = this.dalamud.ClientState.JobGauges.Get<MCHGauge>();
                     // End overheat slightly early to prevent eager button mashing clipping your gcd with a fake 6th HB.
                     if (gauge.IsOverheated() && level >= 35 && gauge.OverheatTimeRemaining > 30) return 7410;
@@ -399,7 +417,8 @@ namespace Dalamud.Game.Internal.Gui {
                             if (level >= 26) return 2873;
                         }
                     }
-                    return 7411;
+                    if (level >= 54) return 7411;
+                    return 2866;
                 }
             }
 
@@ -524,20 +543,21 @@ namespace Dalamud.Game.Internal.Gui {
                 }
             }
 
-            // Change Energy Drain into Fester
+            // Change Fester into Energy Drain
             if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerEDFesterCombo)) {
-                if (actionID == 16508) {
-                    if (this.dalamud.ClientState.JobGauges.Get<SMNGauge>().HasAetherflowStacks())
-                        return 181;
-                    return 16508;
+                if (actionID == 181) {
+                    if (!this.dalamud.ClientState.JobGauges.Get<SMNGauge>().HasAetherflowStacks())
+                        return 16508;
+                    return 181;
                 }
             }
 
-            //Change Energy Siphon into Painflare
+            //Change Painflare into Energy Syphon
             if (this.dalamud.Configuration.ComboPresets.HasFlag(CustomComboPreset.SummonerESPainflareCombo)) {
-                if (actionID == 16510) {
-                    if (this.dalamud.ClientState.JobGauges.Get<SMNGauge>().HasAetherflowStacks())
-                        if (level >= 52) return 3578;
+                if (actionID == 3578) {
+                    if (!this.dalamud.ClientState.JobGauges.Get<SMNGauge>().HasAetherflowStacks())
+                        return 16510;
+                    if (level >= 52) return 3578;
                     return 16510;
                 }
             }
@@ -879,7 +899,7 @@ namespace Dalamud.Game.Internal.Gui {
             CustomIDs.Add(2255);
             CustomIDs.Add(16488);
             CustomIDs.Add(16145);
-            CustomIDs.Add(16146);
+            CustomIDs.Add(16150);
             CustomIDs.Add(16149);
             CustomIDs.Add(7413);
             CustomIDs.Add(2870);
@@ -889,8 +909,8 @@ namespace Dalamud.Game.Internal.Gui {
             CustomIDs.Add(3582);
             CustomIDs.Add(3581);
             CustomIDs.Add(163);
-            CustomIDs.Add(16508);
-            CustomIDs.Add(16510);
+            CustomIDs.Add(181);
+            CustomIDs.Add(3578);
             CustomIDs.Add(16543);
             CustomIDs.Add(167);
             CustomIDs.Add(15994);
@@ -904,6 +924,9 @@ namespace Dalamud.Game.Internal.Gui {
             CustomIDs.Add(16525);
             CustomIDs.Add(16524);
             CustomIDs.Add(7516);
+            CustomIDs.Add(3566);
+            CustomIDs.Add(92);
+            CustomIDs.Add(2866);
             VanillaIDs.Add(0x3e75);
             VanillaIDs.Add(0x3e76);
             VanillaIDs.Add(0x3e77);
@@ -1061,7 +1084,6 @@ namespace Dalamud.Game.Internal.Gui {
             VanillaIDs.Add(0x8d4);
             VanillaIDs.Add(0x8d5);
             VanillaIDs.Add(0x8d7);
-            VanillaIDs.Add(0xb32);
             VanillaIDs.Add(0xb34);
             VanillaIDs.Add(0xb38);
             VanillaIDs.Add(0xb39);
@@ -1072,7 +1094,6 @@ namespace Dalamud.Game.Internal.Gui {
             VanillaIDs.Add(0x31);
             VanillaIDs.Add(0x33);
             VanillaIDs.Add(0x4b);
-            VanillaIDs.Add(0x5c);
             VanillaIDs.Add(0x62);
             VanillaIDs.Add(0x64);
             VanillaIDs.Add(0x71);


### PR DESCRIPTION
I'm open to full release after the next patch breaks things. There hasn't been a crackdown yet, so it's probably fine? Other than the fact that some things are disabled, this ought to be a comprehensive list of "guaranteed good" icon swaps.