### PR TITLE
5.18 updates

### DIFF
--- a/Dalamud.Injector/Dalamud.Injector.csproj
+++ b/Dalamud.Injector/Dalamud.Injector.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
   <PropertyGroup Label="Feature">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>4.1.0.8</AssemblyVersion>
-    <FileVersion>4.1.0.8</FileVersion>
+    <AssemblyVersion>4.4.0.0</AssemblyVersion>
+    <FileVersion>4.4.0.0</FileVersion>
     <Description>XIVLauncher addon injection</Description>
-    <Version>4.1.0.8</Version>
+    <Version>4.4.0.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile></DocumentationFile>

--- a/Dalamud/Dalamud.csproj
+++ b/Dalamud/Dalamud.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Target">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetFramework>net471</TargetFramework>
@@ -14,9 +14,9 @@
   </PropertyGroup>
   <PropertyGroup Label="Feature">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>4.3.0.0</AssemblyVersion>
-    <Version>4.3.0.0</Version>
-    <FileVersion>4.3.0.0</FileVersion>
+    <AssemblyVersion>4.4.0.0</AssemblyVersion>
+    <Version>4.4.0.0</Version>
+    <FileVersion>4.4.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup Label="Resources">
     <None Include="$(SolutionDir)/Resources/**/*" CopyToOutputDirectory="PreserveNewest" Visible="false" />

--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.ClientState
         public IntPtr JobGaugeData { get; set; }
         
         protected override void Setup64Bit(SigScanner sig) {
-            ActorTable = sig.Module.BaseAddress + 0x1BFBA38;
+            ActorTable = sig.Module.BaseAddress + 0x1BFFD90;
             LocalContentId = sig.Module.BaseAddress + 0x1C2E000;
             JobGaugeData = sig.Module.BaseAddress + 0x1C00110;
         }

--- a/Dalamud/Game/Network/NetworkHandlers.cs
+++ b/Dalamud/Game/Network/NetworkHandlers.cs
@@ -221,12 +221,12 @@ namespace Dalamud.Game.Network {
         }
 
         private enum ZoneOpCode {
-            CfNotifyPop = 0x135,
-            CfPreferredRole = 0x2a2,
-            MarketTaxRates = 0x16a,
-            MarketBoardItemRequestStart = 0x349,
-            MarketBoardOfferings = 0x130,
-            MarketBoardHistory = 0x1f7
+            CfNotifyPop = 0x1F8,
+            CfPreferredRole = 0x32A,
+            MarketTaxRates = 0x25E,
+            MarketBoardItemRequestStart = 0x328,
+            MarketBoardOfferings = 0x15F,
+            MarketBoardHistory = 0x113
         }
 
         private DalamudConfiguration.PreferredRole RoleKeyToPreferredRole(int key) => key switch


### PR DESCRIPTION
I picked 4.4.0 for assembly versions, but I wasn't sure what scheme you used for them.  I assumed lower numbers were for game hotfixes.

This actor table location is correct for nhaama for RP info (and there is a PR for it too). I didn't check if it worked properly here as well.