### PR TITLE
"Fix" Dispose crash, handle some disable logic, update plugin delegate to a simple wrapped handler

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -140,6 +140,8 @@ namespace Dalamud {
         }
 
         public void Dispose() {
+            this.InterfaceManager.Dispose();
+
             Framework.Dispose();
 
             this.BotManager.Dispose();

--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -85,7 +85,7 @@ namespace Dalamud {
             this.WinSock2 = new WinSockHandlers();
 
             this.InterfaceManager = new InterfaceManager(this.sigScanner);
-            this.InterfaceManager.ReadyToDraw += (sender, args) => this.InterfaceManager.OnBuildUi += BuildDalamudUi;
+            this.InterfaceManager.OnDraw += BuildDalamudUi;
             this.InterfaceManager.Enable();
 
             try {

--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -1,5 +1,3 @@
-//#define RENDERDOC_HACKS
-
 using System;
 using System.Runtime.InteropServices;
 using Dalamud.Game;
@@ -27,20 +25,6 @@ namespace Dalamud.Interface
 {
     public class InterfaceManager : IDisposable
     {
-#if RENDERDOC_HACKS
-        [DllImport("user32.dll", SetLastError = true)]
-        static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
-
-        [DllImport("RDocHelper.dll")]
-        static extern IntPtr GetWrappedDevice(IntPtr window);
-
-        [DllImport("RDocHelper.dll")]
-        static extern void StartCapture(IntPtr device, IntPtr window);
-
-        [DllImport("RDocHelper.dll")]
-        static extern uint EndCapture();
-#endif
-
         [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
         private delegate IntPtr PresentDelegate(IntPtr swapChain, uint syncInterval, uint presentFlags);
 
@@ -98,13 +82,7 @@ namespace Dalamud.Interface
         {
             if (this.scene == null)
             {
-#if RENDERDOC_HACKS
-                var hWnd = FindWindow(null, "FINAL FANTASY XIV");
-                var device = GetWrappedDevice(hWnd);
-                this.scene = new RawDX11Scene(device, swapChain);
-#else
                 this.scene = new RawDX11Scene(swapChain);
-#endif
                 this.scene.OnBuildUI += HandleMouseUI;
                 this.ReadyToDraw?.Invoke(this, null);
             }


### PR DESCRIPTION
I didn't add anything for a scene builder etc that could be given to the delegates to actually get the name/id/etc to use for ImGui.PushID()

I'd mainly give this a test to see if unloading now works for you.  I know this is ugly, but I was unable to get it to fail after around 100 unloads and rehooks, tried at all the built-in fps options from 15fps to vsync off.