### PR TITLE
Add support for loading images for use in ImGui windows

### DIFF
--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -109,6 +109,32 @@ namespace Dalamud.Interface
             this.presentHook.Dispose();
         }
 
+        public TextureWrap LoadImage(string filePath)
+        {
+            try
+            {
+                return this.scene?.LoadImage(filePath) ?? null;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Failed to load image from {filePath}");
+            }
+            return null;
+        }
+
+        public TextureWrap LoadImage(byte[] imageData)
+        {
+            try
+            {
+                return this.scene?.LoadImage(imageData) ?? null;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load image from memory");
+            }
+            return null;
+        }
+
         private IntPtr PresentDetour(IntPtr swapChain, uint syncInterval, uint presentFlags)
         {
             if (this.scene == null)

--- a/Dalamud/Interface/UiBuilder.cs
+++ b/Dalamud/Interface/UiBuilder.cs
@@ -26,6 +26,22 @@ namespace Dalamud.Interface
             this.interfaceManager.OnDraw -= OnDraw;
         }
 
+        /// <summary>
+        /// Loads an image from the specified file.
+        /// </summary>
+        /// <param name="filePath">The full filepath to the image.</param>
+        /// <returns>A <see cref="TextureWrap"/> object wrapping the created image.  Use <see cref="TextureWrap.ImGuiHandle"/> inside ImGui.Image()</returns>
+        public TextureWrap LoadImage(string filePath) =>
+            this.interfaceManager.LoadImage(filePath);
+
+        /// <summary>
+        /// Loads an image from a byte stream, such as a png downloaded into memory.
+        /// </summary>
+        /// <param name="imageData">A byte array containing the raw image data.</param>
+        /// <returns>A <see cref="TextureWrap"/> object wrapping the created image.  Use <see cref="TextureWrap.ImGuiHandle"/> inside ImGui.Image()</returns>
+        public TextureWrap LoadImage(byte[] imageData) =>
+            this.interfaceManager.LoadImage(imageData);
+
         private void OnDraw() {
             ImGui.PushID(this.namespaceName);
             OnBuildUi?.Invoke();


### PR DESCRIPTION
Added a wrapper around stbi_image to ImGuiScene's embedded scene.  Should work trivially for most types of disk and network images.