### PR TITLE
Fix #38 - resizing the game window was causing swapchain ResizeBuffer…

### DIFF
--- a/Dalamud/Game/Internal/DXGI/ISwapChainAddressResolver.cs
+++ b/Dalamud/Game/Internal/DXGI/ISwapChainAddressResolver.cs
@@ -3,5 +3,6 @@ using System;
 namespace Dalamud.Game.Internal.DXGI {
     public interface ISwapChainAddressResolver {
         IntPtr Present { get; set; }
+        IntPtr ResizeBuffers { get; set; }
     }
 }

--- a/Dalamud/Game/Internal/DXGI/SwapChainSigResolver.cs
+++ b/Dalamud/Game/Internal/DXGI/SwapChainSigResolver.cs
@@ -11,7 +11,7 @@ namespace Dalamud.Game.Internal.DXGI
     public sealed class SwapChainSigResolver : BaseAddressResolver, ISwapChainAddressResolver
     {
         public IntPtr Present { get; set; }
-        //public IntPtr ResizeBuffers { get; private set; }
+        public IntPtr ResizeBuffers { get; set; }
 
         protected override void Setup64Bit(SigScanner sig)
         {
@@ -24,9 +24,7 @@ namespace Dalamud.Game.Internal.DXGI
             // This(code after the function head - offset of it) was picked to avoid running into issues with other hooks being installed into this function.
             Present = scanner.ScanModule("41 8B F0 8B FA 89 54 24 ?? 48 8B D9 48 89 4D ?? C6 44 24 ?? 00") - 0x37;
 
-
-            // seems unnecessary for now, but we may need to handle it
-            //ResizeBuffers = scanner.ScanModule("48 8B C4 55 41 54 41 55 41 56 41 57 48 8D 68 ?? 48 81 EC C0 00 00 00");
+            ResizeBuffers = scanner.ScanModule("48 8B C4 55 41 54 41 55 41 56 41 57 48 8D 68 ?? 48 81 EC C0 00 00 00");
         }
     }
 }

--- a/Dalamud/Game/Internal/DXGI/SwapChainVtableResolver.cs
+++ b/Dalamud/Game/Internal/DXGI/SwapChainVtableResolver.cs
@@ -59,6 +59,7 @@ namespace Dalamud.Game.Internal.DXGI
         #region Addresses
 
         public IntPtr Present { get; set; }
+        public IntPtr ResizeBuffers { get; set; }
 
         #endregion
 
@@ -93,6 +94,7 @@ namespace Dalamud.Game.Internal.DXGI
             }
 
             Present = this.dxgiSwapChainVTblAddresses[8];
+            ResizeBuffers = this.dxgiSwapChainVTblAddresses[13];
         }
     }
 }


### PR DESCRIPTION
…s() to fail, leading to corrupt render targets.

2 part fix:
1) Actually hook ResizeBuffers() so we can release things properly.
2) Essentially, the transient (per-frame) state backup object was not cleaning up fast enough, and was holding references to the render target view(s), which causes ResizeBuffers() to fail.  SharpDX does implement automatic Dispose() properly for all those objects to call Release(), but it seemingly wasn't happening in time.  This fix forces it on the only objects that matter - we could clear them all, but the rest won't break things and it's probably best to leave it up to the GC.

A random opengl fix I made ages ago also got pulled in, it is obviously irrelevant.