### PR TITLE
Fix extraneous error log if dalamud crashes/exits before the game ever renders a frame

### DIFF
--- a/Dalamud/Interface/InterfaceManager.cs
+++ b/Dalamud/Interface/InterfaceManager.cs
@@ -117,7 +117,7 @@ namespace Dalamud.Interface
             this.Disable();
             System.Threading.Thread.Sleep(100);
 
-            this.scene.Dispose();
+            this.scene?.Dispose();
             this.presentHook.Dispose();
             this.resizeBuffersHook.Dispose();
         }


### PR DESCRIPTION
This should almost never happen, but it does confuse the issue by creating an additional error log if something went wrong between the creation of the interface manager and the first present call.  Seen in a recent XL report.