### PR TITLE
Fix devPlugins not being able to load

### DIFF
--- a/Dalamud/Plugin/PluginManager.cs
+++ b/Dalamud/Plugin/PluginManager.cs
@@ -101,17 +101,21 @@ namespace Dalamud.Plugin
                         var defJsonFile = new FileInfo(Path.Combine(dllFile.Directory.FullName, $"{Path.GetFileNameWithoutExtension(dllFile.Name)}.json"));
 
                         PluginDefinition pluginDef = null;
-                        if (defJsonFile.Exists && !raw)
+                        if (defJsonFile.Exists)
                         {
-                            Log.Information("Loading definition for plugin DLL {0}", dllFile.FullName);
+                            if (!raw)
+                            {
+                                Log.Information("Loading definition for plugin DLL {0}", dllFile.FullName);
 
-                            pluginDef =
-                                JsonConvert.DeserializeObject<PluginDefinition>(
-                                    File.ReadAllText(defJsonFile.FullName));
+                                pluginDef =
+                                    JsonConvert.DeserializeObject<PluginDefinition>(
+                                        File.ReadAllText(defJsonFile.FullName));
 
-                            if (pluginDef.ApplicableVersion != this.dalamud.StartInfo.GameVersion && pluginDef.ApplicableVersion != "any") {
-                                Log.Information("Plugin {0} has not applicable version.", dllFile.FullName);
-                                return false;
+                                if (pluginDef.ApplicableVersion != this.dalamud.StartInfo.GameVersion && pluginDef.ApplicableVersion != "any")
+                                {
+                                    Log.Information("Plugin {0} has not applicable version.", dllFile.FullName);
+                                    return false;
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
The plugin definition json is now optional for devPlugins (still required for installedPlugins).  If it's present, it will be used; otherwise a generic default will be created, just to avoid crashing in places like ImGui namespace handling etc.