### PR TITLE
Add GetStaticAddressFromSig

### DIFF
--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -13,9 +13,9 @@ namespace Dalamud.Game.ClientState
         public IntPtr JobGaugeData { get; set; }
         
         protected override void Setup64Bit(SigScanner sig) {
-            ActorTable = sig.Module.BaseAddress + 0x1C62198;        // updated 5.21
+            ActorTable = sig.GetStaticAddressFromSig("F3 0F 11 05 ?? ?? ?? ?? EB 27", 0) + 0xC;
             LocalContentId = sig.Module.BaseAddress + 0x1C2E000;
-            JobGaugeData = sig.Module.BaseAddress + 0x1C5E420;
+            JobGaugeData = sig.GetStaticAddressFromSig("E8 ?? ?? ?? ?? 80 BB ?? ?? ?? ?? ?? 77 93", 0x220) + 0x10;
         }
     }
 }

--- a/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
+++ b/Dalamud/Game/ClientState/ClientStateAddressResolver.cs
@@ -13,7 +13,7 @@ namespace Dalamud.Game.ClientState
         public IntPtr JobGaugeData { get; set; }
         
         protected override void Setup64Bit(SigScanner sig) {
-            ActorTable = sig.GetStaticAddressFromSig("F3 0F 11 05 ?? ?? ?? ?? EB 27", 0) + 0xC;
+            ActorTable = sig.GetStaticAddressFromSig("48 8D 0D ?? ?? ?? ?? 85 ED", 0) + 0x148;
             LocalContentId = sig.Module.BaseAddress + 0x1C2E000;
             JobGaugeData = sig.GetStaticAddressFromSig("E8 ?? ?? ?? ?? 80 BB ?? ?? ?? ?? ?? 77 93", 0x220) + 0x10;
         }

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -166,12 +166,34 @@ namespace Dalamud.Game {
         /// Helper for ScanText to get the correct address for 
         /// IDA sigs that mark the first CALL location.
         /// </summary>
-        /// <param name="sigLocation">The address the CALL sig resolved to.</param>
+        /// <param name="SigLocation">The address the CALL sig resolved to.</param>
         /// <returns>The real offset of the signature.</returns>
         private IntPtr ReadCallSig(IntPtr SigLocation)
         {
             int jumpOffset = Marshal.ReadInt32(IntPtr.Add(SigLocation, 1));
             return IntPtr.Add(SigLocation, 5 + jumpOffset);
+        }
+
+        /// <summary>
+        /// Scan for a .data address using a .text function.
+        /// This is intended to be used with IDA sigs.
+        /// Place your cursor on the line calling a static address, and create and IDA sig.
+        /// </summary>
+        /// <param name="signature">The signature of the function using the data.</param>
+        /// <param name="offset">The offset from function start of the instruction using the data.</param>
+        /// <returns>An IntPtr to the static memory location.</returns>
+        public IntPtr GetStaticAddressFromSig(string signature, int offset)
+        {
+            IntPtr instrAddr = ScanText(signature);
+            instrAddr = IntPtr.Add(instrAddr, offset + 1);
+            long bAddr = (long)Module.BaseAddress;
+            var num = (long)Marshal.ReadInt32(instrAddr) + (long)instrAddr + 4 - bAddr;
+            while(! (num >= DataSectionOffset && num <= DataSectionOffset + DataSectionSize))
+            {
+                instrAddr= IntPtr.Add(instrAddr, 1);
+                num = Marshal.ReadInt32(instrAddr) + (long)instrAddr + 4 - bAddr;
+            }
+            return IntPtr.Add(instrAddr, Marshal.ReadInt32(instrAddr) + 4);
         }
 
         /// <summary>

--- a/Dalamud/Game/SigScanner.cs
+++ b/Dalamud/Game/SigScanner.cs
@@ -185,14 +185,15 @@ namespace Dalamud.Game {
         public IntPtr GetStaticAddressFromSig(string signature, int offset)
         {
             IntPtr instrAddr = ScanText(signature);
-            instrAddr = IntPtr.Add(instrAddr, offset + 1);
+            instrAddr = IntPtr.Add(instrAddr, offset);
             long bAddr = (long)Module.BaseAddress;
-            var num = (long)Marshal.ReadInt32(instrAddr) + (long)instrAddr + 4 - bAddr;
-            while(! (num >= DataSectionOffset && num <= DataSectionOffset + DataSectionSize))
+            long num;
+            do
             {
-                instrAddr= IntPtr.Add(instrAddr, 1);
+                instrAddr = IntPtr.Add(instrAddr, 1);
                 num = Marshal.ReadInt32(instrAddr) + (long)instrAddr + 4 - bAddr;
             }
+            while (!(num >= DataSectionOffset && num <= DataSectionOffset + DataSectionSize));
             return IntPtr.Add(instrAddr, Marshal.ReadInt32(instrAddr) + 4);
         }
 


### PR DESCRIPTION
Adds `GetStaticAddressFromSig`, a function whose purpose is to automatically grab addresses that would need to be manually updated every patch. Since all static data must be called from a function, the goal of this function is to jump to the instruction that references the data, and scan through the instruction until a suitable address is found. All addresses found should exist in .data space.