### PR TITLE
fix discord name handling (and subsequent character lookup) of local player chats in party/alliance

### DIFF
--- a/Dalamud/DiscordBot/DiscordBotManager.cs
+++ b/Dalamud/DiscordBot/DiscordBotManager.cs
@@ -189,12 +189,20 @@ namespace Dalamud.DiscordBot {
             if (playerLink == null) {
                 // chat messages from the local player do not include a player link, and are just the raw name
                 // but we should still track other instances to know if this is ever an issue otherwise
-                if (parsedSender.TextValue != this.dalamud.ClientState.LocalPlayer.Name)
+
+                // Special case 2 - When the local player talks in party/alliance, the name comes through as raw text,
+                // but prefixed by their position number in the party (which for local player may always be 1)
+                if (parsedSender.TextValue.EndsWith(this.dalamud.ClientState.LocalPlayer.Name))
+                {
+                    senderName = this.dalamud.ClientState.LocalPlayer.Name;
+                }
+                else
                 {
                     Log.Error("playerLink was null. Sender: {0}", BitConverter.ToString(sender.RawData));
+
+                    senderName = wasOutgoingTell ? this.dalamud.ClientState.LocalPlayer.Name : parsedSender.TextValue;
                 }
 
-                senderName = wasOutgoingTell ? this.dalamud.ClientState.LocalPlayer.Name : parsedSender.TextValue;
                 senderWorld = this.dalamud.ClientState.LocalPlayer.HomeWorld.Name;
             } else {
                 playerLink.Resolve();


### PR DESCRIPTION
Minor annoyance that is a continuation of a previous fix.

Local player chats don't send a player link, just the name as text.  I addressed this in an earlier fix.

But one case was missed, where if you are in a party or alliance, the name that is sent as text includes the party position number 'character' (more of their special unicode, for their custom number icons in text).  So instead of "Your Name", it comes in as "[1]Your Name", where the [1] is custom unicode.

This was breaking discord handling of your party chats, by displaying the name with the extra 'box'/invalid character, and breaking character lookup and linking.

This fix is kind of dumb but works, and I'm not aware of any other cases.