### PR TITLE
fix race condition with plugin render vs dispose, on Dalamud dispose

### DIFF
--- a/Dalamud/Dalamud.cs
+++ b/Dalamud/Dalamud.cs
@@ -135,6 +135,12 @@ namespace Dalamud {
         }
 
         public void Dispose() {
+            // this must be done before unloading plugins, or it can cause a race condition
+            // due to rendering happening on another thread, where a plugin might receive
+            // a render call after it has been disposed, which can crash if it attempts to
+            // use any resources that it freed in its own Dispose method
+            this.InterfaceManager.Dispose();
+
             try
             {
                 this.PluginManager.UnloadPlugins();
@@ -145,8 +151,6 @@ namespace Dalamud {
                     "[XIVLAUNCHER] There was an error unloading additional plugins. Please check the log for more details.");
                 Log.Error(ex, "Plugin unload failed.");
             }
-
-            this.InterfaceManager.Dispose();
 
             this.Framework.Dispose();
             this.ClientState.Dispose();


### PR DESCRIPTION
Mainly seen in crashes when using /xldclose with plugin ui open