### PR TITLE
Add HandleItemOut hook

### DIFF
--- a/Dalamud/Game/Internal/Gui/GameGuiAddressResolver.cs
+++ b/Dalamud/Game/Internal/Gui/GameGuiAddressResolver.cs
@@ -10,7 +10,8 @@ namespace Dalamud.Game.Internal.Gui {
 
         public IntPtr SetGlobalBgm { get; private set; }
         public IntPtr HandleItemHover { get; set; }
-        
+        public IntPtr HandleItemOut { get; set; }
+
         public GameGuiAddressResolver(IntPtr baseAddress) {
             BaseAddress = baseAddress;
         }
@@ -27,6 +28,7 @@ namespace Dalamud.Game.Internal.Gui {
         protected override void Setup64Bit(SigScanner sig) {
             SetGlobalBgm = sig.ScanText("4C 8B 15 ?? ?? ?? ?? 4D 85 D2 74 58");
             HandleItemHover = sig.ScanText("E8 ?? ?? ?? ?? 48 8B 5C 24 ?? 48 89 AE ?? ?? ?? ??");
+            HandleItemOut = sig.ScanText("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 4D");
         }
     }
 }


### PR DESCRIPTION
Allows detecting when no more item is hovered and dispatch event
accordingly.
Also actually fill the HoveredItem property.