### PR TITLE
Make RawX and RawY ints in MapLinkPayload

### DIFF
--- a/Dalamud/Game/Chat/SeStringHandling/Payloads/MapLinkPayload.cs
+++ b/Dalamud/Game/Chat/SeStringHandling/Payloads/MapLinkPayload.cs
@@ -12,8 +12,8 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         // pre-Resolve() values
         public uint TerritoryTypeId { get; set; }
         public uint MapId { get; set;  }
-        public uint RawX { get; set; }
-        public uint RawY { get; set; }
+        public int RawX { get; set; }
+        public int RawY { get; set; }
 
         // Resolved values
         // It might make sense to have Territory be an external type, that has assorted relevant info
@@ -29,8 +29,8 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
             // eventually we should allow creation using 'nice' values that then encode properly
 
             var packedTerritoryAndMapBytes = MakePackedInteger(TerritoryTypeId, MapId);
-            var xBytes = MakeInteger(RawX);
-            var yBytes = MakeInteger(RawY);
+            var xBytes = MakeInteger((uint)RawX);
+            var yBytes = MakeInteger((uint)RawY);
 
             var chunkLen = 4 + packedTerritoryAndMapBytes.Length + xBytes.Length + yBytes.Length;
 
@@ -68,8 +68,8 @@ namespace Dalamud.Game.Chat.SeStringHandling.Payloads
         protected override void ProcessChunkImpl(BinaryReader reader, long endOfStream)
         {
             (TerritoryTypeId, MapId) = GetPackedIntegers(reader);
-            RawX = (uint)GetInteger(reader);
-            RawY = (uint)GetInteger(reader);
+            RawX = (int)GetInteger(reader);
+            RawY = (int)GetInteger(reader);
             // the Z coordinate is never in this chunk, just the text (if applicable)
 
             // seems to always be FF 01


### PR DESCRIPTION
I found out RawX and RawY because:
- The raw coordinates (0, 0) is roughly the middle flag coordinates (21.5, 21.5)
- Going a bit to the left (or up) they jump to 4.2 billion (which makes it easy to tell its just the sign bit being set)